### PR TITLE
Jason/edit habit

### DIFF
--- a/google_sheets.py
+++ b/google_sheets.py
@@ -118,6 +118,31 @@ def show_habits(creds, spreadsheet_id):
         print("  " + " | ".join(row))
     print() # print a newline
 
+'''set_target_completion_date prompts the user to input a date that they hope to complete the habit by.'''
+def set_target_completion_date():
+    target_date_input = input("Enter target date for completion (YYYY-MM-DD), or leave blank for 'TBD': ")
+    if target_date_input:
+        target_date = datetime.strptime(target_date_input, "%Y-%m-%d").strftime("%A, %B %d")  # "Wednesday, April 23"
+    else:
+        target_date = "TBD"  # Default if no date is provided
+
+    return target_date
+
+'''set_target_completion_time prompts the user to input a time that they hope to complete the habit by.'''
+def set_target_completion_time():
+    # Ask the user for a target time
+    target_time_input = input("Enter target time (HH:MM AM/PM), or leave blank for 'TBD': ")
+    if target_time_input:
+        try:
+            target_time = datetime.strptime(target_time_input, "%I:%M %p").strftime("%I:%M %p")  # "02:37 PM"
+        except ValueError:
+            print("Invalid time format. Please enter time in the format HH:MM AM/PM.")
+            return
+    else:
+        target_time = "TBD"  # Default if no time is provided
+
+    return target_time
+
 '''add_habit adds a new habit to the Google Sheet.'''
 def add_habit(creds, spreadsheet_id, habit):
     service = build('sheets', 'v4', credentials=creds)
@@ -130,22 +155,9 @@ def add_habit(creds, spreadsheet_id, habit):
     creation_date = datetime.now(local_tz).strftime("%A, %B %d at %I:%M %p")  # "Wednesday, April 23 at 2:37 PM"
 
     # Ask the user for a target completion date
-    target_date_input = input("Enter target date for completion (YYYY-MM-DD), or leave blank for 'TBD': ")
-    if target_date_input:
-        target_date = datetime.strptime(target_date_input, "%Y-%m-%d").strftime("%A, %B %d")  # "Wednesday, April 23"
-    else:
-        target_date = "TBD"  # Default if no date is provided
+    target_date = set_target_completion_date()
 
-    # Ask the user for a target time
-    target_time_input = input("Enter target time (HH:MM AM/PM), or leave blank for 'TBD': ")
-    if target_time_input:
-        try:
-            target_time = datetime.strptime(target_time_input, "%I:%M %p").strftime("%I:%M %p")  # "02:37 PM"
-        except ValueError:
-            print("Invalid time format. Please enter time in the format HH:MM AM/PM.")
-            return
-    else:
-        target_time = "TBD"  # Default if no time is provided
+    target_time = set_target_completion_time()
 
     # Set the default completion status to "❌" (incomplete)
     completion_status = "❌"

--- a/google_sheets.py
+++ b/google_sheets.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import pytz
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from datetime import datetime
 from googleapiclient.discovery import build
 
@@ -193,7 +194,6 @@ def edit_habit(creds, spreadsheet_id):
 
     try:
         choice = int(input("\nEnter the number of the habit to edit: "))
-        update_timestamp(creds,spreadsheet_id,choice+1)
 
         if choice < 1 or choice > len(data):
             print("Invalid selection.\n")
@@ -220,6 +220,7 @@ def edit_habit(creds, spreadsheet_id):
             body=update_body
         ).execute()
         print(f"\n✅ Habit updated to '{new_value}' successfully!\n")
+        update_timestamp(creds,spreadsheet_id,choice+1)
     except Exception as e:
         print(f"❌ Error updating habit: {e}")
 
@@ -278,7 +279,7 @@ def delete_habit(creds, spreadsheet_id):
         index = int(input("\nEnter the number of the habit to delete: ")) - 1
         habit_to_delete = habits[index]
     except (ValueError, IndexError):
-        print("❌ Invalid selection.\n")
+        print("Invalid selection.\n")
         return
 
     try:

--- a/main.py
+++ b/main.py
@@ -86,10 +86,10 @@ def main():
         elif choice == "5":
             show_habits(creds, spreadsheet_id)
         elif choice == "6":
-            print("Goodbye!")
+            print("\nGoodbye!")
             break
         else:
-            print("Invalid choice. Please enter a number 1-6.")
+            print("\nInvalid choice.\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Addressed Issue #18  where the user could previously only edit the habit name. Users may now update all fields besides the habit creation date/time. Upon editing a habit, the updated time field is adjusted to reflect the time the modifications were published.

This PR includes testing for this feature as well.